### PR TITLE
chore: overridden sql-formatter to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8870,9 +8870,9 @@
       "dev": true
     },
     "node_modules/sql-formatter": {
-      "version": "12.2.4",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-12.2.4.tgz",
-      "integrity": "sha512-Qj45LEHSfgrdYDOrAtIkR8SdS10SWcqCIM2WZwQwMKF2v9sM0K2dlThWPS7eYCUrhttZIrU1WwuIwHk7MjsWOw==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.2.0.tgz",
+      "integrity": "sha512-k1gDOblvmtzmrBT687Y167ElwQI/8KrlhfKeIUXsi6jw7Rp5n3G8TkMFZF0Z9NG7rAzHKXUlJ8kfmcIfMf5lFg==",
       "dependencies": {
         "argparse": "^2.0.1",
         "get-stdin": "=8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-microservice-common",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-microservice-common",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.525.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-microservice-common",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Common package to be used in CVS microservices",
   "author": "DVSA",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -71,5 +71,10 @@
       "npm run lint:fix",
       "npm run format"
     ]
+  },
+  "overrides": {
+    "mybatis-mapper": {
+      "sql-formatter": "^15.2.0"
+    }
   }
 }


### PR DESCRIPTION
## Description

Dependency mybatis-mapper is using a version of sql-formatter that has an active XSS vulnerability.

There is a PR open to upgrade this version [here](https://github.com/OldBlackJoe/mybatis-mapper/pull/38).

Until this PR is merged, our builds are failing. This PR overrides the sql-formatter version and is intended to be a temporary resolution while the PR above is open.