### PR TITLE
chore: revert overrides in package

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,5 @@
+version: v1.5.0
+ignore:
+    'SNYK-JS-RAILROADDIAGRAMS-6282875':
+     - '* > railroad-diagrams':
+        reason: 'No fix available - file with vulnerability not used'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-microservice-common",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-microservice-common",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.525.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8870,9 +8870,9 @@
       "dev": true
     },
     "node_modules/sql-formatter": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.2.0.tgz",
-      "integrity": "sha512-k1gDOblvmtzmrBT687Y167ElwQI/8KrlhfKeIUXsi6jw7Rp5n3G8TkMFZF0Z9NG7rAzHKXUlJ8kfmcIfMf5lFg==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-12.2.4.tgz",
+      "integrity": "sha512-Qj45LEHSfgrdYDOrAtIkR8SdS10SWcqCIM2WZwQwMKF2v9sM0K2dlThWPS7eYCUrhttZIrU1WwuIwHk7MjsWOw==",
       "dependencies": {
         "argparse": "^2.0.1",
         "get-stdin": "=8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-microservice-common",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Common package to be used in CVS microservices",
   "author": "DVSA",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -71,10 +71,5 @@
       "npm run lint:fix",
       "npm run format"
     ]
-  },
-  "overrides": {
-    "mybatis-mapper": {
-      "sql-formatter": "^15.2.0"
-    }
   }
 }


### PR DESCRIPTION
Previous commit reverted as the snyk error is with a dependent package that does not currently have a fix available.

The error is in a file that isn't actually used when importing this package. This PR contains an override for snyk to ignore this particular issue.